### PR TITLE
Allow custom IP addresses and the app subnet in the storage account

### DIFF
--- a/infra/app/vnet.bicep
+++ b/infra/app/vnet.bicep
@@ -29,7 +29,6 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
     subnets: [
       {
         name: peSubnetName
-        // id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'private-endpoints-subnet')
         properties: {
           addressPrefixes: [
             '10.0.1.0/28' // allows for 11 usable IP addresses
@@ -38,14 +37,17 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
           privateEndpointNetworkPolicies: 'Disabled'
           privateLinkServiceNetworkPolicies: 'Enabled'
         }
-        // type: 'Microsoft.Network/virtualNetworks/subnets'
       }
       {
         name: appSubnetName
-        // id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'app')
         properties: {
           addressPrefixes: [
             '10.0.2.0/26' // allows for 59 usable IP addresses
+          ]
+          serviceEndpoints: [
+            {
+              service: 'Microsoft.Storage'
+            }
           ]
           delegations: [
             {
@@ -55,13 +57,11 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
                 //Microsoft.App/environments is the correct delegation for Flex Consumption VNet integration
                 serviceName: 'Microsoft.App/environments'
               }
-              // type: 'Microsoft.Network/virtualNetworks/subnets/delegations'
             }
           ]
           privateEndpointNetworkPolicies: 'Disabled'
           privateLinkServiceNetworkPolicies: 'Enabled'
         }
-        // type: 'Microsoft.Network/virtualNetworks/subnets'
       }
     ]
     virtualNetworkPeerings: []

--- a/infra/app/vnet.bicep
+++ b/infra/app/vnet.bicep
@@ -12,7 +12,7 @@ param appSubnetName string = 'app'
 
 param tags object = {}
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
   name: vNetName
   location: location
   tags: tags
@@ -29,7 +29,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
     subnets: [
       {
         name: peSubnetName
-        id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'private-endpoints-subnet')
+        // id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'private-endpoints-subnet')
         properties: {
           addressPrefixes: [
             '10.0.1.0/28' // allows for 11 usable IP addresses
@@ -38,11 +38,11 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
           privateEndpointNetworkPolicies: 'Disabled'
           privateLinkServiceNetworkPolicies: 'Enabled'
         }
-        type: 'Microsoft.Network/virtualNetworks/subnets'
+        // type: 'Microsoft.Network/virtualNetworks/subnets'
       }
       {
         name: appSubnetName
-        id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'app')
+        // id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'app')
         properties: {
           addressPrefixes: [
             '10.0.2.0/26' // allows for 59 usable IP addresses
@@ -55,21 +55,25 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
                 //Microsoft.App/environments is the correct delegation for Flex Consumption VNet integration
                 serviceName: 'Microsoft.App/environments'
               }
-              type: 'Microsoft.Network/virtualNetworks/subnets/delegations'
+              // type: 'Microsoft.Network/virtualNetworks/subnets/delegations'
             }
           ]
           privateEndpointNetworkPolicies: 'Disabled'
           privateLinkServiceNetworkPolicies: 'Enabled'
         }
-        type: 'Microsoft.Network/virtualNetworks/subnets'
+        // type: 'Microsoft.Network/virtualNetworks/subnets'
       }
     ]
     virtualNetworkPeerings: []
     enableDdosProtection: false
+  }
+
+  resource appSubnet 'subnets' existing = {
+    name: appSubnetName
   }
 }
 
 output peSubnetName string = virtualNetwork.properties.subnets[0].name
 output peSubnetID string = virtualNetwork.properties.subnets[0].id
 output appSubnetName string = virtualNetwork.properties.subnets[1].name
-output appSubnetID string = virtualNetwork.properties.subnets[1].id
+output appSubnetID string = virtualNetwork::appSubnet.id

--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -22,11 +22,10 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     allowBlobPublicAccess: allowBlobPublicAccess
     publicNetworkAccess: publicNetworkAccess
     allowSharedKeyAccess: false
-    //defaultToOAuthAuthentication: true
+    defaultToOAuthAuthentication: true
     networkAcls: {
       bypass: 'AzureServices'
       defaultAction: 'Deny'
-      //virtualNetworkRules: map([virtualNetworkSubnetId], subnetId => { id: subnetId })
       virtualNetworkRules: [
         {
           id: virtualNetworkSubnetId

--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -3,14 +3,15 @@ param location string = resourceGroup().location
 param tags object = {}
 
 param allowBlobPublicAccess bool = false
-@allowed(['Enabled', 'Disabled'])
+@allowed(['Enabled', 'Disabled', 'SecuredByPerimeter'])
 param publicNetworkAccess string = 'Enabled'
 param containers array = []
 param kind string = 'StorageV2'
 param minimumTlsVersion string = 'TLS1_2'
 param sku object = { name: 'Standard_LRS' }
+param virtualNetworkSubnetId string
 
-resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name
   location: location
   tags: tags
@@ -21,20 +22,29 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
     allowBlobPublicAccess: allowBlobPublicAccess
     publicNetworkAccess: publicNetworkAccess
     allowSharedKeyAccess: false
+    //defaultToOAuthAuthentication: true
     networkAcls: {
       bypass: 'AzureServices'
-      defaultAction: 'Allow'
+      defaultAction: 'Deny'
+      //virtualNetworkRules: map([virtualNetworkSubnetId], subnetId => { id: subnetId })
+      virtualNetworkRules: [
+        {
+          id: virtualNetworkSubnetId
+        }
+      ]
     }
   }
 
   resource blobServices 'blobServices' = if (!empty(containers)) {
     name: 'default'
-    resource container 'containers' = [for container in containers: {
-      name: container.name
-      properties: {
-        publicAccess: contains(container, 'publicAccess') ? container.publicAccess : 'None'
+    resource container 'containers' = [
+      for container in containers: {
+        name: container.name
+        properties: {
+          publicAccess: contains(container, 'publicAccess') ? container.publicAccess : 'None'
+        }
       }
-    }]
+    ]
   }
 }
 

--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -9,7 +9,15 @@ param containers array = []
 param kind string = 'StorageV2'
 param minimumTlsVersion string = 'TLS1_2'
 param sku object = { name: 'Standard_LRS' }
+param allowedIpAddresses array
 param virtualNetworkSubnetId string
+
+var ipRules = [
+  for ipAddress in allowedIpAddresses: {
+    action: 'Allow'
+    value: ipAddress
+  }
+]
 
 resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name
@@ -26,6 +34,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     networkAcls: {
       bypass: 'AzureServices'
       defaultAction: 'Deny'
+      ipRules: ipRules
       virtualNetworkRules: [
         {
           id: virtualNetworkSubnetId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -77,7 +77,8 @@ module storage './core/storage/storage-account.bicep' = {
     location: location
     tags: tags
     containers: [{name: 'deploymentpackage'}]
-    publicNetworkAccess: 'Disabled'
+    publicNetworkAccess: 'Enabled'
+    virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,6 +15,9 @@ param environmentName string
 })
 param location string
 
+@description('List of the public IP addresses allowed to connect to the storage account.')
+param allowedIpAddresses array
+
 param processorServiceName string = ''
 param processorUserAssignedIdentityName string = ''
 param applicationInsightsName string = ''
@@ -78,6 +81,7 @@ module storage './core/storage/storage-account.bicep' = {
     tags: tags
     containers: [{name: 'deploymentpackage'}]
     publicNetworkAccess: 'Enabled'
+    allowedIpAddresses:allowedIpAddresses
     virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
   }
 }


### PR DESCRIPTION
## Purpose

Changes the network settings in the storage account to enable public access only from:
- The app subnet
- Custom public IP addresses

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Yvand/functions-quickstart-typescript-azd.git
cd functions-quickstart-typescript-azd
git checkout allow-subnet-in-storage
npm install
azd provision
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
Go to the Azure portal > storage account > Networking:
Public network access is set to "Enabled from selected virtual networks and IP addresses", and:
- The subnet "app" is added
- Specified IP addresses are allowed

## Other Information
<!-- Add any other helpful information that may be needed here. -->