### PR TITLE
add keyvault and choice for managed identity type

### DIFF
--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -127,6 +127,7 @@
     "synapseWorkspacesSqlPoolsDedicated": "syndp",
     "synapseWorkspacesSqlPoolsSpark": "synsp",
     "timeSeriesInsightsEnvironments": "tsi-",
+    "vaultAccounts": "vault-",
     "webServerFarms": "plan-",
     "webSitesAppService": "app-",
     "webSitesAppServiceEnvironment": "ase-",

--- a/infra/app/processor.bicep
+++ b/infra/app/processor.bicep
@@ -4,8 +4,8 @@ param tags object = {}
 param applicationInsightsName string = ''
 param appServicePlanId string
 param appSettings object = {}
-param runtimeName string 
-param runtimeVersion string 
+param runtimeName string
+param runtimeVersion string
 param serviceName string = 'processor'
 param storageAccountName string
 param virtualNetworkSubnetId string = ''
@@ -13,8 +13,15 @@ param instanceMemoryMB int = 2048
 param maximumInstanceCount int = 100
 param identityId string = ''
 param identityClientId string = ''
+@allowed(['SystemAssigned', 'UserAssigned'])
+param identityType string
 
-var applicationInsightsIdentity = 'ClientId=${identityClientId};Authorization=AAD'
+var managedIdentityAuthSettings = identityType == 'UserAssigned'
+  ? {
+      AzureWebJobsStorage__clientId: identityClientId
+      APPLICATIONINSIGHTS_AUTHENTICATION_STRING: 'ClientId=${identityClientId};Authorization=AAD'
+    }
+  : {}
 
 module processor '../core/host/functions-flexconsumption.bicep' = {
   name: '${serviceName}-functions-module'
@@ -22,20 +29,16 @@ module processor '../core/host/functions-flexconsumption.bicep' = {
     name: name
     location: location
     tags: union(tags, { 'azd-service-name': serviceName })
-    identityType: 'UserAssigned'
+    identityType: identityType
     identityId: identityId
-    appSettings: union(appSettings,
-      {
-        AzureWebJobsStorage__clientId : identityClientId
-        APPLICATIONINSIGHTS_AUTHENTICATION_STRING: applicationInsightsIdentity
-      })
+    appSettings: union(appSettings, managedIdentityAuthSettings)
     applicationInsightsName: applicationInsightsName
     appServicePlanId: appServicePlanId
     runtimeName: runtimeName
     runtimeVersion: runtimeVersion
     storageAccountName: storageAccountName
     virtualNetworkSubnetId: virtualNetworkSubnetId
-    instanceMemoryMB: instanceMemoryMB 
+    instanceMemoryMB: instanceMemoryMB
     maximumInstanceCount: maximumInstanceCount
   }
 }

--- a/infra/app/vnet.bicep
+++ b/infra/app/vnet.bicep
@@ -48,6 +48,9 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
             {
               service: 'Microsoft.Storage'
             }
+            {
+              service: 'Microsoft.KeyVault'
+            }
           ]
           delegations: [
             {

--- a/infra/core/host/functions-flexconsumption.bicep
+++ b/infra/core/host/functions-flexconsumption.bicep
@@ -76,9 +76,11 @@ resource functions 'Microsoft.Web/sites@2023-12-01' = {
     }
     virtualNetworkSubnetId: virtualNetworkSubnetId
     keyVaultReferenceIdentity: identityType == 'UserAssigned' ? identityId : 'SystemAssigned'
+    vnetRouteAllEnabled: true // workaround to access network-restricted vaults: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli#access-network-restricted-vaults
 
     siteConfig: {
       keyVaultReferenceIdentity: identityType == 'UserAssigned' ? identityId : 'SystemAssigned'
+      //vnetRouteAllEnabled: true // workaround to access network-restricted vaults: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli#access-network-restricted-vaults
     }
   }
 

--- a/infra/core/vault/vault-access.bicep
+++ b/infra/core/vault/vault-access.bicep
@@ -1,0 +1,20 @@
+param principalID string
+param roleDefinitionID string
+param keyVaultName string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+// Allow access from API to storage account using a managed identity
+resource vaultRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, principalID, roleDefinitionID)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: roleDefinitionID
+    principalId: principalID
+    principalType: 'ServicePrincipal' // Workaround for https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template#new-service-principal
+  }
+}
+
+output ROLE_ASSIGNMENT_NAME string = vaultRoleAssignment.name

--- a/infra/core/vault/vault-resource.bicep
+++ b/infra/core/vault/vault-resource.bicep
@@ -8,6 +8,7 @@ param publicNetworkAccess string = 'Disabled'
 param sku object = { family: 'A', name: 'standard' }
 param allowedIpAddresses array
 param virtualNetworkSubnetId string
+param enableSoftDelete bool = true
 
 var ipRules = [
   for ipAddress in allowedIpAddresses: {
@@ -22,6 +23,7 @@ resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   properties: {
     sku: sku
     tenantId: tenantId
+    enableSoftDelete: enableSoftDelete
     enableRbacAuthorization: true
     publicNetworkAccess: publicNetworkAccess
     networkAcls: {

--- a/infra/core/vault/vault-resource.bicep
+++ b/infra/core/vault/vault-resource.bicep
@@ -1,0 +1,42 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param tenantId string
+
+@allowed(['Enabled', 'Disabled'])
+param publicNetworkAccess string = 'Disabled'
+param sku object = { family: 'A', name: 'standard' }
+param allowedIpAddresses array
+param virtualNetworkSubnetId string
+
+var ipRules = [
+  for ipAddress in allowedIpAddresses: {
+    value: ipAddress
+  }
+]
+
+resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: sku
+    tenantId: tenantId
+    enableRbacAuthorization: true
+    publicNetworkAccess: publicNetworkAccess
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+      ipRules: ipRules
+      // virtualNetworkRules: map([virtualNetworkSubnetId], subnetId => { id: subnetId })
+      virtualNetworkRules: [
+        {
+          id: virtualNetworkSubnetId
+        }
+      ]
+    }
+  }
+}
+
+output id string = vault.id
+output name string = vault.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -26,7 +26,11 @@ param logAnalyticsName string = ''
 param resourceGroupName string = ''
 param storageAccountName string = ''
 param vNetName string = ''
+param vaultName string = ''
 param disableLocalAuth bool = true
+param publicNetworkAccess string = 'Enabled'
+@allowed(['SystemAssigned', 'UserAssigned'])
+param appServiceIdentityType string = 'SystemAssigned'
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
@@ -40,7 +44,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 }
 
 // User assigned managed identity to be used by the Function App to reach storage and service bus
-module processorUserAssignedIdentity './core/identity/userAssignedIdentity.bicep' = {
+module processorUserAssignedIdentity './core/identity/userAssignedIdentity.bicep' = if (appServiceIdentityType == 'UserAssigned') {
   name: 'processorUserAssignedIdentity'
   scope: rg
   params: {
@@ -63,8 +67,9 @@ module processor './app/processor.bicep' = {
     runtimeName: 'node'
     runtimeVersion: '20'
     storageAccountName: storage.outputs.name
-    identityId: processorUserAssignedIdentity.outputs.identityId
-    identityClientId: processorUserAssignedIdentity.outputs.identityClientId
+    identityType: appServiceIdentityType
+    identityId: appServiceIdentityType == 'UserAssigned' ? processorUserAssignedIdentity.outputs.identityId : ''
+    identityClientId: appServiceIdentityType == 'UserAssigned' ? processorUserAssignedIdentity.outputs.identityClientId : ''
     appSettings: {
     }
     virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
@@ -80,7 +85,7 @@ module storage './core/storage/storage-account.bicep' = {
     location: location
     tags: tags
     containers: [{name: 'deploymentpackage'}]
-    publicNetworkAccess: 'Enabled'
+    publicNetworkAccess: publicNetworkAccess
     allowedIpAddresses:allowedIpAddresses
     virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
   }
@@ -95,7 +100,7 @@ module storageRoleAssignmentApi 'app/storage-Access.bicep' = {
   params: {
     storageAccountName: storage.outputs.name
     roleDefinitionID: storageRoleDefinitionId
-    principalID: processorUserAssignedIdentity.outputs.identityPrincipalId
+    principalID: appServiceIdentityType == 'UserAssigned' ? processorUserAssignedIdentity.outputs.identityPrincipalId : processor.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
   }
 }
 
@@ -158,7 +163,39 @@ module appInsightsRoleAssignmentApi './core/monitor/appinsights-access.bicep' = 
   params: {
     appInsightsName: monitoring.outputs.applicationInsightsName
     roleDefinitionID: monitoringRoleDefinitionId
-    principalID: processorUserAssignedIdentity.outputs.identityPrincipalId
+    principalID: appServiceIdentityType == 'UserAssigned' ? processorUserAssignedIdentity.outputs.identityPrincipalId : processor.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
+  }
+}
+
+// Keyvault
+module vault './core/vault/vault-resource.bicep' = {
+  name: 'vault'
+  scope: rg
+  params: {
+    name: !empty(vaultName) ? vaultName : '${abbrs.vaultAccounts}${resourceToken}'
+    location: location
+    tags: tags
+    publicNetworkAccess: publicNetworkAccess
+    allowedIpAddresses: allowedIpAddresses
+    virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
+    tenantId: tenant().tenantId
+  }
+}
+
+@description('This is the built-in Key Vault Secrets User role. See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#key-vault-administrator')
+resource keyVaultSecretsUserRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' existing = {
+  scope: subscription()
+  name: '4633458b-17de-408a-b874-0445c86b69e6'
+}
+
+// Allow access from processor to skey vault using a managed identity
+module vaultRoleAssignmentApi './core/vault/vault-access.bicep' = {
+  name: 'vaultRoleAssignmentProcessor'
+  scope: rg
+  params: {
+    keyVaultName: vault.outputs.name
+    roleDefinitionID: keyVaultSecretsUserRoleDefinition.id
+    principalID: appServiceIdentityType == 'UserAssigned' ? processorUserAssignedIdentity.outputs.identityPrincipalId : processor.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,6 +31,7 @@ param disableLocalAuth bool = true
 param publicNetworkAccess string = 'Enabled'
 @allowed(['SystemAssigned', 'UserAssigned'])
 param appServiceIdentityType string = 'SystemAssigned'
+param keyVaultEnableSoftDelete bool = true
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
@@ -179,6 +180,7 @@ module vault './core/vault/vault-resource.bicep' = {
     allowedIpAddresses: allowedIpAddresses
     virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
     tenantId: tenant().tenantId
+    enableSoftDelete: keyVaultEnableSoftDelete
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,7 +15,7 @@ param environmentName string
 })
 param location string
 
-@description('List of the public IP addresses allowed to connect to the storage account.')
+@description('List of the public IP addresses allowed to connect to the storage account and the key vault.')
 param allowedIpAddresses array
 
 param processorServiceName string = ''


### PR DESCRIPTION
## Purpose


- Add a key vault 
- Add parameter `appServiceIdentityType` to choose between managed identity types `SystemAssigned` and `UserAssigned`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Yvand/functions-quickstart-typescript-azd.git
cd functions-quickstart-typescript-azd
git checkout add-key-vault
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check

- A key vault resource was created
- Parameter `appServiceIdentityType` allows to choose the type of the managed identity assigned to the app service
- The managed identity assigned to the app service (whether its type is `SystemAssigned` or `UserAssigned`) has the role `Key Vault Secrets User` granted to the key vault

## Other Information
<!-- Add any other helpful information that may be needed here. -->